### PR TITLE
[fix] correct Auth Domain API Bugs

### DIFF
--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/auth/controller/AuthController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/auth/controller/AuthController.java
@@ -24,15 +24,15 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    @Operation(summary = "❌ 로그인 / 엑세스 토큰 발급", description = "로그인 (JWT Access-Token) ")
+    @Operation(summary = "✅ 로그인 / 엑세스 토큰 발급", description = "로그인 (JWT Access-Token) ")
     public ResponseEntity<SuccessResponse<LoginResponse>> accessToken(@RequestBody LoginRequest request) {
         var result = authService.issueToken(request);
         return ResponseFactory.success(result);
     }
 
 
-    @PostMapping("/auth/refresh")
-    @Operation(summary = "❌ accessToken 토큰 재발급  ", description = "리프레시 토큰으로 엑세스 토큰 재발급")
+    @PostMapping("/refresh")
+    @Operation(summary = "✅ accessToken 토큰 재발급  ", description = "리프레시 토큰으로 엑세스 토큰 재발급")
     public ResponseEntity<SuccessResponse<RefreshResponse>> reissueToken(
             @RequestBody RefreshRequest request
 //            HttpServletRequest request

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/mail/controller/EmailController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/mail/controller/EmailController.java
@@ -25,7 +25,7 @@ public class EmailController {
 
     private final MailService mailService;
 
-    @Operation(summary = "❌ 이메일 인증 코드 전송",
+    @Operation(summary = "✅ 이메일 인증 코드 전송",
             description = "로그인X, 비밀번호 수정을 위한 이메일 인증 코드 전송 API")
     @PostMapping("/mail/send")
     public ResponseEntity<SuccessResponse<EmailResponse>> sendAuthCode(
@@ -35,7 +35,7 @@ public class EmailController {
         return ResponseFactory.success(result);
     }
 
-    @Operation(summary = "❌ 인증 코드 검증",
+    @Operation(summary = "✅ 인증 코드 검증",
             description = "이메일로 전송된 인증 코드를 검증하는 API")
     @PostMapping("/mail/verify")
     public ResponseEntity<SuccessResponse<EmailVerifyResponse>> verifyMail(@Valid @RequestBody EmailVerifyRequest request) {

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/mail/service/MailService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/mail/service/MailService.java
@@ -36,14 +36,15 @@ public class MailService {
     private final JWTService jwtService;
 
     // 인증번호 만료 시간 5분
-    @Value("${spring.service.authCodeExpiryTime}") private Duration authCodeExpiryTime;
+    @Value("${spring.service.authCodeExpiryTime}") private int authCodeExpiryTime;
     @Value("${spring.mail.username}") private String senderEmail;
 
 
     public EmailResponse sendAuthCode(String username) {
         String email = userQueryService.findByUsername(username).getEmail();
         String authCode = generateAuthCode();
-        redisService.setValues(email, authCode, authCodeExpiryTime);
+
+        redisService.setValues(email, authCode, Duration.ofMinutes(authCodeExpiryTime));
 
 //      메일 생성
         MimeMessage message = createMailContext(email, authCode);


### PR DESCRIPTION
### Auth 도메인의 API 관련 버그 수정

#### 주요 변경 사항
**API 엔드포인트 수정**: `/auth/auth/refresh` → `/auth/refresh` 

**API 기능 테스트 현황**: 
-`/auth/login`❌ → `/auth/login`✅ 
-`/auth/refresh`❌ → `/auth/refresh`✅ 
-`/auth/mail/send`❌ → `/auth/mail/send`✅ 
-`/auth//mail/verify`❌ → `/auth/mail/verify`✅ 