### PR TITLE
Update the API version 2.4.7

### DIFF
--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/config/SecurityConfig.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/config/SecurityConfig.java
@@ -131,7 +131,7 @@ public class SecurityConfig {
                                         "/policies/**").hasAnyAuthority(ROLE_ADMIN)
                                 // PolicySchedule
                                 .requestMatchers(
-                                        "/schedules/available-dates").permitAll()
+                                        "/schedules/available-dates/**").permitAll()
                                 .requestMatchers(
                                         "/schedules/**").hasAnyAuthority(ROLE_ADMIN)
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/partition/repository/RoomPartitionRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/partition/repository/RoomPartitionRepository.java
@@ -2,6 +2,7 @@ package hufs.computer.studyroom.domain.partition.repository;
 
 import hufs.computer.studyroom.domain.partition.entity.RoomPartition;
 import hufs.computer.studyroom.domain.partition.entity.RoomPartition;
+import hufs.computer.studyroom.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,6 +12,6 @@ public interface RoomPartitionRepository extends JpaRepository<RoomPartition,Lon
 //   RoomID로 PartitionId들 찾기
     List<RoomPartition> findByRoom_RoomId(Long roomId);
 
-    //   특정 Department에 속하는 모든 RoomPartition을 조회
-    List<RoomPartition> findAllByRoomDepartmentDepartmentId(Long departmentId);
+
+    List<RoomPartition> findByRoomIn(List<Room> rooms);
 }

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/AnyReservationController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/AnyReservationController.java
@@ -21,12 +21,12 @@ import java.time.LocalDate;
 public class AnyReservationController {
         private final ReservationQueryService reservationQueryService;
 
-        @Operation(summary = "❌ 특정 날짜 ,특정 부서가 관리하는 모든 파티션의 예약 상태 조회",
+        @Operation(summary = "✅[예약 현황 테이블] 특정 날짜 ,특정 부서가 관리하는 모든 파티션의 예약 상태 조회",
                 description = "날짜를 받으면 룸(파티션 집합)들의 예약을 확인, 예약 현황 테이블을 그릴때 사용",
                 security = {})
         @GetMapping("/by-date/{departmentId}")
         ResponseEntity<SuccessResponse<AllPartitionsReservationStatusResponse>> getPartitionReservationsByDepartmentAndDate(
-                @ExistDepartment @PathVariable("departmentId") Long departmentId,
+                @ExistDepartment @PathVariable("departmentId") Long departmentId, // todo :  헤더 필터링으로 (추출)
                 @RequestParam("date") LocalDate date) {
             var result = reservationQueryService.getPartitionReservationsByDepartmentAndDate(departmentId, date);
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/room/repository/RoomRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/room/repository/RoomRepository.java
@@ -12,4 +12,6 @@ import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<Room,Long> {
     // JpaRepository 에서 인터페이스 CrudRepository 가 기본 CRUD 기능을 제공
+
+    List<Room> findAllByDepartmentDepartmentId(Long departmentId);
 }

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AdminScheduleController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AdminScheduleController.java
@@ -31,7 +31,7 @@ public class AdminScheduleController {
 
 
     // todo : 트랜잭션
-    @Operation(summary = "❌[관리자] 여러 schedule 생성",
+    @Operation(summary = "✅[관리자] 여러 schedule 생성",
             description = "여러 스케쥴 생성/ 여러개의 방에 여러 날짜에 스케쥴 생성 ",
             security = {@SecurityRequirement(name = "JWT")})
     @PostMapping()
@@ -40,7 +40,7 @@ public class AdminScheduleController {
         return ResponseFactory.created(result);
     }
 
-    @Operation(summary = "❌[관리자] schedule 조회",
+    @Operation(summary = "✅[관리자] schedule 조회",
             description = "스케쥴 조회",
             security = {@SecurityRequirement(name = "JWT")})
     @GetMapping("/{roomOperationPolicyScheduleId}")
@@ -59,7 +59,7 @@ public class AdminScheduleController {
     }
 
 
-    @Operation(summary = "❌[관리자] schedule 업데이트",
+    @Operation(summary = "✅[관리자] schedule 업데이트",
             description = "해당 스케쥴 업데이트",
             security = {@SecurityRequirement(name = "JWT")})
     @PutMapping("/schedule/{roomOperationPolicyScheduleId}")

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AdminScheduleController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AdminScheduleController.java
@@ -49,7 +49,7 @@ public class AdminScheduleController {
         return ResponseFactory.success(result);
     }
 
-    @Operation(summary = "❌[관리자] 해당날짜의 schedule 들 조회",
+    @Operation(summary = "✅[관리자] 해당날짜의 schedule 들 조회",
             description = "스케쥴 조회",
             security = {@SecurityRequirement(name = "JWT")})
     @GetMapping("date/{policyApplicationDate}")
@@ -72,7 +72,7 @@ public class AdminScheduleController {
 
     }
 
-    @Operation(summary = "❌[관리자] schedule 삭제",
+    @Operation(summary = "✅[관리자] schedule 삭제",
             description = "해당 schedule id의 정보 삭제 API",
             security = {@SecurityRequirement(name = "JWT")}
     )

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AnyScheduleController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AnyScheduleController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AnyScheduleController {
     private final ScheduleQueryService scheduleQueryService;
-    @Operation(summary = "✅ 현재로 부터 미래까지 운영 정책이 설정된 방이 있는 날짜를 조회",
+    @Operation(summary = "🚧 현재로 부터 미래까지 운영 정책이 설정된 방이 있는 날짜를 조회",
             description = "현재로 부터 예약가능한 방들을 날짜를 기준으로 묶어 조회"
     )
-    @GetMapping("/available-dates")
-    public ResponseEntity<SuccessResponse<AvailableDateResponses>> getAvailableDatesFromToday() {
-        var result = scheduleQueryService.getAvailableDatesFromToday();
+    @GetMapping("/available-dates/{departmentId}")
+    public ResponseEntity<SuccessResponse<AvailableDateResponses>> getAvailableDatesFromToday(@PathVariable Long departmentId) {
+        var result = scheduleQueryService.getAvailableDatesFromToday(departmentId);
         return ResponseFactory.success(result);
     }
 }

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AnyScheduleController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/controller/AnyScheduleController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AnyScheduleController {
     private final ScheduleQueryService scheduleQueryService;
-    @Operation(summary = "❌ 현재로 부터 미래까지 운영 정책이 설정된 방이 있는 날짜를 조회",
+    @Operation(summary = "✅ 현재로 부터 미래까지 운영 정책이 설정된 방이 있는 날짜를 조회",
             description = "현재로 부터 예약가능한 방들을 날짜를 기준으로 묶어 조회"
     )
     @GetMapping("/available-dates")

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/dto/request/ModifyScheduleRequest.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/dto/request/ModifyScheduleRequest.java
@@ -1,8 +1,9 @@
 package hufs.computer.studyroom.domain.schedule.dto.request;
 
-import hufs.computer.studyroom.common.validation.annotation.policy.ExistPolicy;
 import hufs.computer.studyroom.common.validation.annotation.ExistRoom;
+import hufs.computer.studyroom.common.validation.annotation.policy.ExistPolicy;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -10,8 +11,8 @@ import java.time.LocalDate;
 @Builder
 @Schema(description = "스케줄 정보 수정 요청 DTO")
 public record ModifyScheduleRequest(
-        @ExistRoom @Schema(description = "방 ID", example = "1") Long roomId,
-        @ExistPolicy @Schema(description = "정책 ID", example = "3") Long roomOperationPolicyId,
-        @Schema(description = "정책 적용 날짜", example = "2024-10-09") LocalDate policyApplicationDate
+        @NotNull @ExistRoom @Schema(description = "방 ID", example = "1") Long roomId,
+        @NotNull @ExistPolicy @Schema(description = "정책 ID", example = "3") Long roomOperationPolicyId,
+        @NotNull @Schema(description = "정책 적용 날짜", example = "2024-11-15") LocalDate policyApplicationDate
 )
 {}

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/mapper/RoomOperationPolicyScheduleMapper.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/mapper/RoomOperationPolicyScheduleMapper.java
@@ -7,9 +7,7 @@ import hufs.computer.studyroom.domain.schedule.dto.response.AvailableDateRespons
 import hufs.computer.studyroom.domain.schedule.dto.response.ScheduleInfoResponse;
 import hufs.computer.studyroom.domain.schedule.dto.response.ScheduleInfoResponses;
 import hufs.computer.studyroom.domain.schedule.entity.RoomOperationPolicySchedule;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
+import org.mapstruct.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,6 +24,7 @@ public interface RoomOperationPolicyScheduleMapper {
     @Mapping(source = "room.roomId", target = "roomId")
     @Mapping(source = "roomOperationPolicy.roomOperationPolicyId", target = "roomOperationPolicyId")
     ScheduleInfoResponse toScheduleInfoResponse(RoomOperationPolicySchedule schedule);
+
     // ModifyScheduleRequest -> 기존 Schedule 엔티티 수정
     @Mapping(target = "roomOperationPolicyScheduleId", ignore = true)
     void updateFromRequest(ModifyScheduleRequest request,Room room,RoomOperationPolicy roomOperationPolicy, @MappingTarget RoomOperationPolicySchedule schedule);

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/repository/RoomOperationPolicyScheduleRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/repository/RoomOperationPolicyScheduleRepository.java
@@ -21,14 +21,14 @@ public interface RoomOperationPolicyScheduleRepository extends JpaRepository<Roo
     List<RoomOperationPolicySchedule> findByPolicyApplicationDate(LocalDate date);
 
 
-    // 메인 API → 금일 기점으로 미래까지, 어떤방들을 이용할 수 있는지? 단,방들을 날짜로 묶어(Group by) 응답
+    // 메인 API → 특정 부서에서 금일 기점으로 미래까지, 어떤방들을 이용할 수 있는지? 단,방들을 날짜로 묶어(Group by) 응답
     @Query(
             "SELECT DISTINCT this.policyApplicationDate " +
             "FROM RoomOperationPolicySchedule this " +
-            "WHERE this.policyApplicationDate >= :startDate " +
+            "WHERE this.policyApplicationDate >= :startDate AND this.room.department.departmentId = :departmentId " +
             "ORDER BY this.policyApplicationDate"
     )
-    List<LocalDate> findAvailableRoomsGroupedByDate(@Param("startDate") LocalDate startDate);
+    List<LocalDate> findAvailableRoomsGroupedByDate(@Param("startDate") LocalDate startDate,@Param("departmentId") Long departmentId);
 
 
     /**

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/repository/RoomOperationPolicyScheduleRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/repository/RoomOperationPolicyScheduleRepository.java
@@ -15,6 +15,7 @@ public interface RoomOperationPolicyScheduleRepository extends JpaRepository<Roo
     // {특정 날짜에 해당, 특정 방} 의 운영 정책 스케쥴 을 찾는 메소드
     Optional<RoomOperationPolicySchedule> findByRoomAndPolicyApplicationDate(Room room, LocalDate date);
     boolean existsByRoomRoomIdAndPolicyApplicationDate(Long roomId, LocalDate date);
+    boolean existsByRoomAndPolicyApplicationDate(Room room, LocalDate date);
 
 
     // {특정 날짜에 해당 하는 방들} 의 운영 정책 스케쥴 을 찾는 메소드

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleCommandService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleCommandService.java
@@ -66,10 +66,10 @@ public class ScheduleCommandService {
     }
 
     @Transactional
-    public ScheduleInfoResponse updateSchedule(@ExistSchedule Long scheduleId, ModifyScheduleRequest request) {
+    public ScheduleInfoResponse updateSchedule(Long scheduleId, ModifyScheduleRequest request) {
         RoomOperationPolicySchedule schedule = scheduleQueryService.getScheduleById(scheduleId);
-        Room room = schedule.getRoom();
-        RoomOperationPolicy policy = schedule.getRoomOperationPolicy();
+        Room room = roomQueryService.getRoomById(request.roomId());
+        RoomOperationPolicy policy = policyQueryService.getPolicyById(request.roomOperationPolicyId());
 
         scheduleMapper.updateFromRequest(request, room, policy, schedule);
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleQueryService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleQueryService.java
@@ -49,6 +49,7 @@ public class ScheduleQueryService {
         return scheduleRepository.findByRoomAndPolicyApplicationDate(room, date);
         //.orElseThrow(() -> new CustomException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
     }
+    public boolean existsScheduleByRoomAndDate(Room room, LocalDate date) {return scheduleRepository.existsByRoomAndPolicyApplicationDate(room, date);}
     public boolean existByScheduleId(Long scheduleId) {
         return scheduleRepository.existsById(scheduleId);
     }

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleQueryService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleQueryService.java
@@ -35,9 +35,9 @@ public class ScheduleQueryService {
         return scheduleMapper.toScheduleInfoResponses(schedules);
     }
 
-    public AvailableDateResponses getAvailableDatesFromToday() {
+    public AvailableDateResponses getAvailableDatesFromToday(Long departmentId) {
         LocalDate today = LocalDate.now();
-        List<LocalDate> dates = scheduleRepository.findAvailableRoomsGroupedByDate(today);
+        List<LocalDate> dates = scheduleRepository.findAvailableRoomsGroupedByDate(today, departmentId);
         return scheduleMapper.toAvailableDateResponses(dates);
     }
 


### PR DESCRIPTION
# API version 2.4.7 

## 주요 변경사항 
- [PUT] /schedules/schedule/{roomoperationPolicyScheduleId} API 버그 수정 
- [GET] /reservations/by-date/{departmentId} API 버그 수정 
- [GET] /schedules/available-dates API 엔드 포인트, 기능 수정


### API 엔드포인트 수정: 

- [GET] /schedules/available-dates → [GET] /schedules/available-dates/{departmentId}

### 버그 수정: 

기존 특정 날짜,특정 부서가 관리하는 모든 파티션의 예약 상태 조회 API 버그 수정 
- 예약상태 조회시, 일부 파티션에 정책이 설정되지 않은 경우 발생하던 논리 오류 수정 

스케줄 정보 업데이트 API의 버그 수정
- 입력 필드에 대한 DTO 유효성 검사 추가
- 일정 업데이트 프로세스의 논리 오류 수정

### API 기능 테스트 현황:
❌ →  ✅
- [PUT] /schedules/schedule/{roomoperationPolicyScheduleId} [관리자] schedule 업데이트
- [POST] /schedules [관리자] 여러 schedule 생성
- [GET] /schedules/{roomoperationPolicyScheduleId} [관리자] schedule 조회
- [DELETE] /schedules/{roomoperationPolicyScheduleId} [관리자] schedule 삭제
- [GET] /schedules/date/{policyApplicationDate} [관리자] 해당날짜의 schedule 들 조회

❌ →  🚧
- [GET] /schedules/available-dates/{departmentId} 현재로 부터 미래까지 운영 정책이 설정된 방이 있는 날짜를 조회