### PR TITLE
Update the API version 2.4.7 

### DIFF
--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleCommandService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/schedule/service/ScheduleCommandService.java
@@ -33,6 +33,7 @@ public class ScheduleCommandService {
     private final RoomQueryService roomQueryService;
     private final ScheduleQueryService scheduleQueryService;
 
+    @Transactional
     public ScheduleInfoResponses createSchedules(CreateScheduleBulkRequest request) {
         RoomOperationPolicy policy = policyQueryService.getPolicyById(request.roomOperationPolicyId());
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/controller/AdminUserController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/controller/AdminUserController.java
@@ -5,6 +5,7 @@ import hufs.computer.studyroom.common.response.factory.ResponseFactory;
 import hufs.computer.studyroom.common.validation.annotation.user.ExistUser;
 import hufs.computer.studyroom.domain.user.dto.request.ModifyUserInfoRequest;
 import hufs.computer.studyroom.domain.user.dto.request.SignUpBulkRequest;
+import hufs.computer.studyroom.domain.user.dto.response.UserBlockedInfoResponses;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponse;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponses;
 import hufs.computer.studyroom.domain.user.service.UserCommandService;
@@ -72,7 +73,7 @@ public class AdminUserController {
             description = "관리용 예약 조회",
             security = {@SecurityRequirement(name = "JWT")})
     @GetMapping("/blocked")
-    public ResponseEntity<SuccessResponse<UserInfoResponses>> getBlockedUserReservationInfo() {
+    public ResponseEntity<SuccessResponse<UserBlockedInfoResponses>> getBlockedUserReservationInfo() {
         var result = userQueryService.findBlockedUser();
 
         return ResponseFactory.success(result);

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/dto/response/UserBlockedInfoResponse.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/dto/response/UserBlockedInfoResponse.java
@@ -1,0 +1,20 @@
+package hufs.computer.studyroom.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+@Schema(description = "블락 회원 정보 응답 DTO")
+public record UserBlockedInfoResponse (
+        @Schema(description = "회원 정보 응답 DTO")
+        UserInfoResponse userInfoResponse,
+
+        @Schema(description = "회원 블락 시작 날짜")
+        LocalDate startBlockedDate,
+
+        @Schema(description = "회원 블락 종료 날짜")
+        LocalDate endBlockedDate
+)
+{}

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/dto/response/UserBlockedInfoResponses.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/dto/response/UserBlockedInfoResponses.java
@@ -1,0 +1,14 @@
+package hufs.computer.studyroom.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "블락 회원 정보 목록 응답 DTO")
+public record UserBlockedInfoResponses(
+    @Schema(description = "블락 회원 정보 응답 DTO")
+    List<UserBlockedInfoResponse> UserBlockedInfoResponses
+) {
+}

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/mapper/UserMapper.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/mapper/UserMapper.java
@@ -3,12 +3,15 @@ package hufs.computer.studyroom.domain.user.mapper;
 import hufs.computer.studyroom.domain.department.entity.Department;
 import hufs.computer.studyroom.domain.user.dto.request.ModifyUserInfoRequest;
 import hufs.computer.studyroom.domain.user.dto.request.SignUpRequest;
+import hufs.computer.studyroom.domain.user.dto.response.UserBlockedInfoResponse;
+import hufs.computer.studyroom.domain.user.dto.response.UserBlockedInfoResponses;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponse;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponses;
 import hufs.computer.studyroom.domain.user.entity.User;
 import hufs.computer.studyroom.domain.user.entity.ServiceRole;
 import org.mapstruct.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Mapper(componentModel = "spring")
@@ -32,6 +35,13 @@ public interface UserMapper {
     @Mapping(target = "department", source = "department")
     void updateUserFromRequest(ModifyUserInfoRequest request, @MappingTarget User user, Department department);
 
+
+    // User -> UserBlockedInfoResponse 변환
+    @Mapping(source = "user", target = "userInfoResponse")
+    UserBlockedInfoResponse toBlockedInfoResponse(User user, LocalDate startBlockedDate, LocalDate endBlockedDate);
+
+
+
     // 여러 User -> 여러 UserInfoResponse DTO 변환
     List<UserInfoResponse> toInfoResponseList(List<User> users);
 
@@ -39,6 +49,13 @@ public interface UserMapper {
     default UserInfoResponses toInfoResponses(List<UserInfoResponse> userInfoResponses) {
         return UserInfoResponses.builder()
                 .users(userInfoResponses)
+                .build();
+    }
+
+    // 여러 UserBlockedInfoResponse DTO -> UserBlockedInfoResponses 변환
+    default UserBlockedInfoResponses toBlockedInfoResponses(List<UserBlockedInfoResponse> userBlockedInfoResponses) {
+        return UserBlockedInfoResponses.builder()
+                .UserBlockedInfoResponses(userBlockedInfoResponses)
                 .build();
     }
 }


### PR DESCRIPTION
# API version 2.4.7 

## 주요 변경사항 
- [GET] /users/blocked API 기능 수정 
- [POST] /schedules API 트랜잭션 추가 

### 로직 수정: 
- 차단된 사용자에 대한 응답 DTO 구조 수정
- 차단 시작 날짜를 검색하는 메서드 추가
- 블록 종료 날짜를 검색하는 메서드 추가
- 노쇼 유효성 검사 로직 리팩터링