### PR TITLE
Update Swagger API version to 2.4.9 for new API additions 

### DIFF
--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/AdminReservationController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/AdminReservationController.java
@@ -3,6 +3,7 @@ package hufs.computer.studyroom.domain.reservation.controller;
 import hufs.computer.studyroom.common.response.SuccessResponse;
 import hufs.computer.studyroom.common.response.factory.ResponseFactory;
 import hufs.computer.studyroom.common.validation.annotation.ExistReservation;
+import hufs.computer.studyroom.common.validation.annotation.user.ExistUser;
 import hufs.computer.studyroom.domain.reservation.dto.request.ModifyReservationStateRequest;
 import hufs.computer.studyroom.domain.reservation.dto.response.BlockedUserNoShowResponses;
 import hufs.computer.studyroom.domain.reservation.dto.response.ReservationInfoResponse;
@@ -57,14 +58,13 @@ public class AdminReservationController {
         return ResponseFactory.modified(result);
     }
 
-    @Operation(summary = "✅[관리자] 학번으로 사용자 예약들 조회",
+    @Operation(summary = "✅[관리자] userId로 사용자의 예약들 조회",
             description = "관리용 예약 조회",
             security = {@SecurityRequirement(name = "JWT")})
-    @GetMapping("/admin/{serial}")
-    public ResponseEntity<SuccessResponse<ReservationInfoResponses>> getReservationBySerial(@AuthenticationPrincipal CustomUserDetails currentUser,
-                                                                                             @PathVariable String serial) {
-//        todo : 관리자 검증 애노테이션 생성
-        var result = reservationQueryService.findAllReservationBySerial(serial, currentUser);
+    @GetMapping("/admin/users/{userId}")
+    public ResponseEntity<SuccessResponse<ReservationInfoResponses>> getReservationByUserId(@ExistUser @PathVariable Long userId) {
+// todo : [의논] 어느 시점까지의 예약을 가져와야할까? 시간이 가면 갈 수 록, 예약이 너무 많아 질텐데,,,
+        var result = reservationQueryService.findAllReservationByUser(userId);
 
         return ResponseFactory.success(result);
     }
@@ -73,7 +73,7 @@ public class AdminReservationController {
             description = "관리용 예약 조회",
             security = {@SecurityRequirement(name = "JWT")})
     @GetMapping("/admin/blocked/users")
-    public ResponseEntity<SuccessResponse<BlockedUserNoShowResponses>> getBlockedUserReservationInfo(@AuthenticationPrincipal CustomUserDetails currentUser) {
+    public ResponseEntity<SuccessResponse<BlockedUserNoShowResponses>> getBlockedUserReservationInfo() {
 //        todo : 관리자 검증 애노테이션 생성
         var result = reservationQueryService.getBlockedUserReservation();
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/UserReservationController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/controller/UserReservationController.java
@@ -71,7 +71,7 @@ public class UserReservationController {
     @GetMapping("/me")
     ResponseEntity<SuccessResponse<ReservationInfoResponses>> lookUpAllHistory(@AuthenticationPrincipal CustomUserDetails currentUser) {
 
-        var result = reservationQueryService.findAllReservationByUser(currentUser);
+        var result = reservationQueryService.findAllReservationByUser(currentUser.getUser().getUserId());
 
         return ResponseFactory.success(result);
     }

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/service/ReservationCommandService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/service/ReservationCommandService.java
@@ -57,6 +57,7 @@ public class ReservationCommandService {
         if (isValid) {
             // No Show 기간이 지났다면 상태 업데이트
             updateNoShowReservationsToProcessed(userId);
+            log.info("[USER INFO] : (Block 기간 만료) 유저 상태 변경 , BLOCKED -> USER");
         }
         validationService.validateRoomAvailability(userId, roomPartitionId, request.startDateTime(), request.endDateTime());
 

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/service/ReservationQueryService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/reservation/service/ReservationQueryService.java
@@ -49,8 +49,9 @@ public class ReservationQueryService {
 
     // 해당 유저의 모든 reservation 로그 찾기
 //    todo : RESERVATION_HISTORY_NOT_FOUND 예외로 처리 할 지, 빈배열 반환을 할지?
-    public ReservationInfoResponses findAllReservationByUser(CustomUserDetails currentUser) {
-        Long userId = currentUser.getUser().getUserId();
+
+    public ReservationInfoResponses findAllReservationByUser(Long userId) {
+//        Long userId = currentUser.getUser().getUserId();
 
         List<Reservation> reservations = reservationRepository.findAllByUserUserId(userId)
                 .orElse(Collections.emptyList());
@@ -60,20 +61,20 @@ public class ReservationQueryService {
     }
 
 //    todo : RESERVATION_HISTORY_NOT_FOUND 예외로 처리 할 지, 빈배열 반환을 할지?
-    public ReservationInfoResponses findAllReservationBySerial(String serial, CustomUserDetails currentUser) {
-        User admin = currentUser.getUser();
-        if (admin.getServiceRole() != null && admin.getServiceRole() != ServiceRole.ADMIN) {
-            throw new CustomException(AuthErrorCode.ACCESS_DENIED);
-        }
-
-        User foundUser = userRepository.findBySerial(serial).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
-        Long userId = foundUser.getUserId();
-        List<Reservation> reservations = reservationRepository.findAllByUserUserId(userId)
-                .orElse(Collections.emptyList());
-//              .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_HISTORY_NOT_FOUND));
-
-        return reservationMapper.toInfoResponses(reservations);
-    }
+//    public ReservationInfoResponses findAllReservationBySerial(String serial, CustomUserDetails currentUser) {
+//        User admin = currentUser.getUser();
+//        if (admin.getServiceRole() != null && admin.getServiceRole() != ServiceRole.ADMIN) {
+//            throw new CustomException(AuthErrorCode.ACCESS_DENIED);
+//        }
+//
+//        User foundUser = userRepository.findBySerial(serial).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+//        Long userId = foundUser.getUserId();
+//        List<Reservation> reservations = reservationRepository.findAllByUserUserId(userId)
+//                .orElse(Collections.emptyList());
+////              .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_HISTORY_NOT_FOUND));
+//
+//        return reservationMapper.toInfoResponses(reservations);
+//    }
 
     /**
      * 사용자 NoShow 예약 목록 조회

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/controller/AdminUserController.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/controller/AdminUserController.java
@@ -34,19 +34,37 @@ public class AdminUserController {
 
     // request param -> json request
     @Operation(summary = "✅ [관리자] 특정 회원 정보 조회",
-            description = "username, password, isAdmin, name, serial 반환",
+            description = "특정 회원을 ID로 조회",
             security = {@SecurityRequirement(name = "JWT")})
-    @GetMapping("/{userId}")
+    @GetMapping("/search/by-id/{userId}")
     public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserById(
             @ExistUser @PathVariable Long userId) {
         var result = userQueryService.findUserById(userId);
         return ResponseFactory.success(result);
     }
 
+    @Operation(summary = "✅ [관리자] 특정 회원 정보 조회",
+            description = "특정 회원을 학번으로 조회",
+            security = {@SecurityRequirement(name = "JWT")})
+    @GetMapping("/search/by-serial")
+    public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserBySerial(@RequestParam String serial) {
+        var result = userQueryService.findUserBySerial(serial);
+        return ResponseFactory.success(result);
+    }
+
+    @Operation(summary = "✅ [관리자] 특정 회원 정보 조회",
+            description = "특정 회원을 이름으로 조회",
+            security = {@SecurityRequirement(name = "JWT")})
+    @GetMapping("/search/by-name")
+    public ResponseEntity<SuccessResponse<UserInfoResponses>> getUserByName(@RequestParam String name){
+        var result = userQueryService.findUserByName(name);
+        return ResponseFactory.success(result);
+    }
+
     @Operation(summary = "✅ [관리자] 모든 회원 정보 조회",
             description = "모든 user 조회 API",
             security = {@SecurityRequirement(name = "JWT")})
-    @GetMapping
+    @GetMapping("/search")
     public ResponseEntity<SuccessResponse<UserInfoResponses>> getAllUsers() {
         var result = userQueryService.findAllUsers();
         return ResponseFactory.success(result);

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/repository/UserRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package hufs.computer.studyroom.domain.user.repository;
 
+import hufs.computer.studyroom.domain.user.entity.ServiceRole;
 import hufs.computer.studyroom.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,8 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Boolean existsBySerial(String serial);
     Boolean existsByEmail(String email);
 
+    @Query("SELECT u.serviceRole FROM User u WHERE u.userId = :userId")
+    ServiceRole findUserServiceRoleByUserId(@Param("userId") Long userId);
     @Query("SELECT u " +
             "FROM User u " +
             "WHERE u.serviceRole = 'BLOCKED'")

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/repository/UserRepository.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/repository/UserRepository.java
@@ -13,8 +13,10 @@ public interface UserRepository extends JpaRepository<User,Long> {
     // JpaRepository 에서 인터페이스 CrudRepository 가 기본 CRUD 기능을 제공
     Optional<User> findByEmail(String email);
     Optional<User> findByUsername(String username);
-    //회원가입 시 중복 여부를 판단하기 위해서 학번으로 회원을 검사하도록 쿼리 메소드 작성
     Optional<User> findBySerial(String serial);
+    List<User> findByName(String name);
+
+
     Boolean existsByUsername(String username);
     Boolean existsBySerial(String serial);
     Boolean existsByEmail(String email);

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserQueryService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserQueryService.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -46,6 +47,16 @@ public class UserQueryService {
     public UserInfoResponse findUserById(Long userId) {
         User user = getUserById(userId);
         return userMapper.toInfoResponse(user);
+    }
+
+    public UserInfoResponse findUserBySerial(String serial) {
+        User user = userRepository.findBySerial(serial).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        return userMapper.toInfoResponse(user);
+    }
+
+    public UserInfoResponses findUserByName(String name) {
+        List<User> users = userRepository.findByName(name);
+        return userMapper.toInfoResponses(userMapper.toInfoResponseList(users));
     }
 
     public UserBlockedInfoResponses findBlockedUser() {

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserQueryService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserQueryService.java
@@ -8,6 +8,7 @@ import hufs.computer.studyroom.domain.user.dto.response.UserBlockedInfoResponse;
 import hufs.computer.studyroom.domain.user.dto.response.UserBlockedInfoResponses;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponse;
 import hufs.computer.studyroom.domain.user.dto.response.UserInfoResponses;
+import hufs.computer.studyroom.domain.user.entity.ServiceRole;
 import hufs.computer.studyroom.domain.user.entity.User;
 import hufs.computer.studyroom.domain.user.mapper.UserMapper;
 import hufs.computer.studyroom.domain.user.repository.UserRepository;
@@ -76,6 +77,7 @@ public class UserQueryService {
         return userRepository.findById(id).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
     }
 
+    public ServiceRole getServiceRoleById(Long id) {return userRepository.findUserServiceRoleByUserId(id);}
     public boolean existByUserId(Long userId) {return userRepository.existsById(userId);}
     public boolean existByUsername(String username) {return userRepository.existsByUsername(username);}
     public boolean existBySerial(String serial) {return userRepository.existsBySerial(serial);}

--- a/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserValidationService.java
+++ b/study-room-reservation-system/src/main/java/hufs/computer/studyroom/domain/user/service/UserValidationService.java
@@ -33,18 +33,25 @@ public class UserValidationService {
 //  가장 마지막으로 생성된 예약의 날짜부터 noShowCntMonth 달 후 까지 블락기간이므로, noShowCntMonth 달 후, 다음날 부터는 이용가능
 
         if (userQueryService.isUserBlockedDueToNoShow(userId)){
-//            User 블락 상태로 변경
-            userCommandService.modifyServiceRoleById(userId, ServiceRole.BLOCKED);
-
             Instant blockEndTime = reservationQueryService.calculateNoShowBlockEndTime(userId);
+            if (isUser(userId)) {
+                // User 블락 상태로 변경
+                log.info("[USER INFO] : 유저 상태 변경 , USER -> BLOCKED");
+                userCommandService.modifyServiceRoleById(userId, ServiceRole.BLOCKED);
+            }
 
             if (Instant.now().isBefore(blockEndTime)) {
+                log.info("[USER INFO] : 유저 No Show 횟수 초과");
                 throw new CustomException(ReservationErrorCode.NO_SHOW_LIMIT_EXCEEDED);
             }
             // No Show 기간이 지났다면 상태 업데이트
             return true;
         }
         return false;
+    }
+
+    private boolean isUser(Long userId) {
+        return userQueryService.getServiceRoleById(userId) == ServiceRole.USER;
     }
 
 


### PR DESCRIPTION
# API version 2.4.9

## 주요 변경사항 
- 사용자 노쇼 검증 로직 리팩터링
- [PUT] /schedules/schedule/{roomoperationPolicyScheduleId} API 버그 수정 
- [GET] /reservations/by-date/{departmentId} API 버그 수정 
- [GET] /schedules/available-dates API 엔드 포인트, 기능 수정

### 신규 API: 
- [GET] /users/search/by-serial : [관리자] 특정 회원 정보 조회
- [GET] /users/search/by-name : [관리자] 특정 회원 정보 조회
- [GET] /reservations/admin/users/{userId} [관리자] userld로 사용자의 예약들 조회

### 삭제된 API:
- [GET] serial로 사용자의 예약들 조회 /reservations/admin/{serial}

### API 엔드포인트 수정: 
/users/{userId}  → /users/search/by-id/{userId}  [관리자] 특정 회원 정보 조회
/users → /users/search [관리자] 모든 회원 정보 조회

